### PR TITLE
Downgrading Swift version for Mojave users

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Swift 5.2 won't build on Mojave. 😢

This has been tested by @ibeckermayer
https://github.com/covid19risk/covidwatch-ios/pull/74 