### PR TITLE
Enabled support for iOS 12 and earlier by using `ed25519swift` library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,7 @@ import PackageDescription
 let package = Package(
     name: "TCNClient",
     platforms: [
-        // TODO: Add support for iOS 12.
-      .iOS(.v13),
+      .iOS(.v12),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
@@ -16,15 +15,14 @@ let package = Package(
             targets: ["TCNClient"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/pebble8888/ed25519swift.git", from: "1.2.5")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "TCNClient",
-            dependencies: []),
+            dependencies: ["ed25519swift"]),
         .testTarget(
             name: "TCNClientTests",
             dependencies: ["TCNClient"]),

--- a/Sources/TCNClient/Crypto/CryptoLib.swift
+++ b/Sources/TCNClient/Crypto/CryptoLib.swift
@@ -1,0 +1,105 @@
+//
+//  Created by Eugene Kolpakov on 2020-04-25.
+//
+
+import Foundation
+import CryptoKit
+import CommonCrypto
+import ed25519swift
+
+@available(iOS 13.0, *)
+extension SHA256.Digest: DataRepresentable {}
+
+/// Generic interface for working with asymmetric keys
+public protocol AsymmetricKeyPair {
+
+    var privateKey: Data { get }
+    var publicKey: Data { get }
+
+    func signature(for data: Data) throws -> Data
+}
+
+
+class CryptoLib {
+
+    static func generateKeyPair() -> AsymmetricKeyPair {
+        if #available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *) {
+            return CryptoKitEllipticCurveKeyPair()
+        } else {
+            return Ed25519LibEllipticCurveKeyPair()
+        }
+    }
+
+    static func restoreKeyPair(serializedSecret: Data) throws -> AsymmetricKeyPair {
+        if #available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *) {
+            return try CryptoKitEllipticCurveKeyPair(rawRepresentation: serializedSecret)
+        } else {
+            return try Ed25519LibEllipticCurveKeyPair(rawRepresentation: serializedSecret)
+        }
+    }
+
+    static func isValidSignature(_ signature: Data, for data: Data, key: Data) throws -> Bool {
+        if #available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *) {
+            let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: key)
+            return publicKey.isValidSignature(signature, for: data)
+        } else {
+            return Ed25519.verify(signature: signature.bytes, message: data.bytes, publicKey: key.bytes)
+        }
+    }
+
+    static func sha256(data : Data) -> Data {
+        if #available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *) {
+            return SHA256.hash(data: data).dataRepresentation
+        } else {
+            var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+            data.withUnsafeBytes {
+                _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
+            }
+            return Data(hash)
+        }
+    }
+}
+
+/// Uses CryptoKit APIs for working with asymmetric keys on OS versions that support CryptoKit.
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+fileprivate struct CryptoKitEllipticCurveKeyPair: AsymmetricKeyPair {
+
+    private let curve25519PrivateKey: Curve25519.Signing.PrivateKey
+
+    var privateKey: Data { return curve25519PrivateKey.rawRepresentation }
+    var publicKey: Data { return curve25519PrivateKey.publicKey.rawRepresentation }
+
+    init() {
+        curve25519PrivateKey = Curve25519.Signing.PrivateKey()
+    }
+
+    init(rawRepresentation: Data) throws {
+        curve25519PrivateKey = try Curve25519.Signing.PrivateKey(rawRepresentation: rawRepresentation)
+    }
+
+    func signature(for data: Data) throws -> Data {
+        return try curve25519PrivateKey.signature(for: data)
+    }
+}
+
+/// Uses `ed25519swift` open-source library for working with asymmetric keys on OS versions that don't support CryptoKit.
+fileprivate struct Ed25519LibEllipticCurveKeyPair: AsymmetricKeyPair {
+
+    let privateKey: Data
+    let publicKey: Data
+
+    init() {
+        let (publicKeyBytes, privateKeyBytes) = Ed25519.generateKeyPair()
+        privateKey = Data(privateKeyBytes)
+        publicKey = Data(publicKeyBytes)
+    }
+
+    init(rawRepresentation: Data) throws {
+        privateKey = rawRepresentation
+        publicKey = Data(Ed25519.calcPublicKey(secretKey: rawRepresentation.bytes))
+    }
+
+    func signature(for data: Data) throws -> Data {
+        return Data(Ed25519.sign(message: data.bytes, secretKey: privateKey.bytes))
+    }
+}

--- a/Sources/TCNClient/Crypto/Report.swift
+++ b/Sources/TCNClient/Crypto/Report.swift
@@ -111,8 +111,7 @@ extension ReportAuthorizationKey {
             temporaryContactKey = temporaryContactKey.ratchet()!
         }
         let report = Report(
-            reportVerificationPublicKeyBytes: reportAuthorizationPrivateKey
-                .publicKey.rawRepresentation,
+            reportVerificationPublicKeyBytes: temporaryContactKey.reportVerificationPublicKeyBytes,
             temporaryContactKeyBytes: temporaryContactKey.bytes,
             // Invariant: we have ensured j_1 > 0 above.
             startIndex: startIndex,
@@ -120,7 +119,7 @@ extension ReportAuthorizationKey {
             memoType: memoType,
             memoData: memoData
         )
-        let signatureBytes = try reportAuthorizationPrivateKey.signature(
+        let signatureBytes = try keyPair.signature(
             for: report.serializedData()
         )
         return SignedReport(report: report, signatureBytes: signatureBytes)
@@ -144,11 +143,6 @@ public struct SignedReport: Equatable {
     
     /// Verify the source integrity of the contained `report`.
     public func verify() throws -> Bool {
-        let publicKey = try Curve25519.Signing.PublicKey(
-            rawRepresentation: report.reportVerificationPublicKeyBytes
-        )
-        return publicKey.isValidSignature(
-            signatureBytes, for: try report.serializedData()
-        )
+        return try CryptoLib.isValidSignature(signatureBytes, for: try report.serializedData(), key: report.reportVerificationPublicKeyBytes)
     }
 }

--- a/Sources/TCNClient/Crypto/Serialization.swift
+++ b/Sources/TCNClient/Crypto/Serialization.swift
@@ -95,13 +95,12 @@ extension ReportAuthorizationKey: TCNSerializable {
         guard serializedData.count == 32 else {
             throw CocoaError(.coderInvalidValue)
         }
-        self.reportAuthorizationPrivateKey = try Curve25519.Signing.PrivateKey(
-            rawRepresentation: serializedData
-        )
+
+        self.keyPair = try CryptoLib.restoreKeyPair(serializedSecret: serializedData)
     }
     
     public func serializedData() -> Data {
-        return reportAuthorizationPrivateKey.rawRepresentation
+        return keyPair.privateKey
     }
     
 }

--- a/Tests/TCNClientTests/TCNClientCryptoTests.swift
+++ b/Tests/TCNClientTests/TCNClientCryptoTests.swift
@@ -83,7 +83,7 @@ final class TCNClientCryptoTests: XCTestCase {
     
     func testBasicReadWriteRoundTrip() {
         do {
-            let reportAuthorizationKey = ReportAuthorizationKey(reportAuthorizationPrivateKey: .init())
+            let reportAuthorizationKey = ReportAuthorizationKey()
             let reportAuthorizationKeySerialization = reportAuthorizationKey.serializedData()
             let newReportAuthorizationKey = try ReportAuthorizationKey(serializedData: reportAuthorizationKeySerialization)
             XCTAssertEqual(reportAuthorizationKey, newReportAuthorizationKey)
@@ -110,7 +110,7 @@ final class TCNClientCryptoTests: XCTestCase {
         do {
             // Generate a report authorization key.  This key represents the capability
             // to publish a report about a collection of derived temporary contact numbers.
-            let reportAuthorizationKey = ReportAuthorizationKey(reportAuthorizationPrivateKey: .init())
+            let reportAuthorizationKey = ReportAuthorizationKey()
             
             // Use the temporary contact key ratchet mechanism to compute a list of contact
             // event numbers.
@@ -175,8 +175,8 @@ final class TCNClientCryptoTests: XCTestCase {
                 "8b454d28430d3153a500359d9a49ec88",
             ]
             
-            let rak = ReportAuthorizationKey(reportAuthorizationPrivateKey: try .init(rawRepresentation: expected_rak_bytes.hexDecodedData()))
-            XCTAssertEqual(rak.reportAuthorizationPrivateKey.rawRepresentation.hexEncodedString(), expected_rak_bytes)
+            let rak = try ReportAuthorizationKey(serializedData: expected_rak_bytes.hexDecodedData())
+            XCTAssertEqual(rak.keyPair.privateKey.hexEncodedString(), expected_rak_bytes)
             
             //            print("here")
             var tck = rak.initialTemporaryContactKey


### PR DESCRIPTION
## Description

This is intended to address https://github.com/TCNCoalition/tcn-client-ios/issues/2 due to absence of CryptoKit framework on iOS 12 and earlier.
I made a little refactoring to make sure `RequestAuthorizationKey`, `Report` and other entities do not depend directly on CryptoKit by using new `CryptoLib` utility class along with `AsymmetricKeyPair` protocol which together wrap logic of choosing crypto library APIs depending on OS version.

## Testing

So far I tested all operations (public key generation, signing, signature verification) on cross-platform compatibility only locally and verified that they are all compatible.

I am going to add unit tests for this in a separate commit. I decided to submit the PR before adding tests to have an early review in case something needs to be corrected or adjusted.


