### PR TITLE
iOS 10 support using CCurve25519 library #2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CCurve25519",
+        "repositoryURL": "https://github.com/christophhagen/CCurve25519.git",
+        "state": {
+          "branch": null,
+          "revision": "f27fa9a2cf0c61a3cb9d9a03b3d3d801ccc64b32",
+          "version": "1.0.4"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/christophhagen/CCurve25519.git", from: "1.0.1")
+        .package(url: "https://github.com/christophhagen/CCurve25519.git", from: "1.0.2")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,7 @@ import PackageDescription
 let package = Package(
     name: "TCNClient",
     platforms: [
-        // TODO: Add support for iOS 12.
-      .iOS(.v13),
+      .iOS(.v10),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
@@ -18,15 +17,16 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/christophhagen/CCurve25519.git", from: "1.0.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "TCNClient",
-            dependencies: []),
+            dependencies: ["CCurve25519"]),
         .testTarget(
             name: "TCNClientTests",
-            dependencies: ["TCNClient"]),
+            dependencies: ["TCNClient", "CCurve25519"]),
     ]
 )

--- a/Sources/TCNClient/Crypto/Curve25519PrivateKey.swift
+++ b/Sources/TCNClient/Crypto/Curve25519PrivateKey.swift
@@ -1,0 +1,194 @@
+//
+//  Curve25519PrivateKey.swift
+//  
+//
+//  Created by Volkov Alexander on 5/3/20.
+//
+
+import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+import CCurve25519
+
+public struct Curve25519KeyLength {
+
+    /// The length of the private and public key in bytes
+    public static let key = 32
+
+    /// The length of a signature in bytes
+    public static let signature = 64
+
+    /// The number of random bytes needed for signing
+    public static let random = 64
+
+    /// The default basepoint for X25519 key agreement
+    public static let basepoint: Data = [9] + Data(repeating: 0, count: 31)
+
+    // MARK: VRF Constants
+    /// The length of a VRF signature in bytes
+    public static let vrfSignature = 96
+
+    /// The number of random bytes needed for signing
+    public static let vrfRandom = 32
+
+    /// The length of the VRF verification output in bytes
+    public static let vrfVerify = 32
+}
+
+public struct Curve25519PrivateKey {
+    
+    public let key: Any!
+    
+    /// The associated public key for verifying signatures done with this private key.
+    ///
+    /// - Returns: The associated public key
+    public var publicKey: Curve25519PublicKey!
+    
+    /// Generates a Curve25519 Signing Key.
+    public init() {
+        if #available(iOS 13.0, *) {
+            self.key = Curve25519.Signing.PrivateKey()
+        } else {
+            self.key = Curve25519PrivateKey.generateRandomData(count: Curve25519KeyLength.key)!
+        }
+        try! initPublicKey()
+    }
+    
+    public init<D>(rawRepresentation data: D) throws where D : ContiguousBytes {
+        if #available(iOS 13.0, *) {
+            self.key = try Curve25519.Signing.PrivateKey(rawRepresentation: data)
+        }
+        else {
+            self.key = data
+        }
+        try initPublicKey()
+    }
+    
+    // Initialize related public key
+    private mutating func initPublicKey() throws {
+        if #available(iOS 13.0, *) {
+            if let key = key as? Curve25519.Signing.PrivateKey {
+                publicKey = Curve25519PublicKey(publicKey: key.publicKey)
+                return
+            }
+        }
+        publicKey = try Curve25519PublicKey(rawRepresentation: Curve25519PrivateKey.generatePublicKey(privateKey: key as! Data))
+    }
+    
+    /// A data representation of the private key
+    public var rawRepresentation: Data {
+        if #available(iOS 13.0, *) {
+            if let key = key as? Curve25519.Signing.PrivateKey {
+                return key.rawRepresentation
+            }
+        }
+        return key as! Data
+    }
+    
+    /// Generates an EdDSA signature over Curve25519.
+    ///
+    /// - Parameter data: The data to sign.
+    /// - Returns: The 64-bytes signature.
+    /// - Throws: If there is a failure producing the signature.
+    public func signature<D>(for data: D) throws -> Data where D : DataProtocol {
+        if #available(iOS 13.0, *) {
+            if let key = key as? Curve25519.Signing.PrivateKey {
+                return try key.signature(for: data)
+            }
+        }
+        return try Curve25519PrivateKey.signature(for: data as! Data, privateKey: key as! Data, randomData: Curve25519PrivateKey.generateRandomData(count: Curve25519KeyLength.random)!)
+    }
+    
+    /// Generate random private key
+    public static func generateRandomData(count: Int) -> Data? {
+        
+        var keyData = Data(count: count)
+        let result = keyData.withUnsafeMutableBytes {
+            SecRandomCopyBytes(kSecRandomDefault, Curve25519KeyLength.key, $0.baseAddress!)
+        }
+        if result == errSecSuccess {
+            return keyData
+        } else {
+            print("Problem generating random bytes")
+            return nil
+        }
+    }
+    
+    public static func generatePublicKey(privateKey: Data, basepoint: Data = Curve25519KeyLength.basepoint) throws -> Data {
+        var privateKey: Data = privateKey
+        guard privateKey.count == Curve25519KeyLength.key else { throw "Incorrect private key length: \(privateKey.count)" }
+        guard basepoint.count == Curve25519KeyLength.key else { throw "Incorrect basepoint length: \(privateKey.count)" }
+        
+        var data = Data(count: Curve25519KeyLength.key)
+        let result: Int32 = data.withUnsafeMutableBytes { (keyPtr: UnsafeMutablePointer<UInt8>) in
+            privateKey.withUnsafeMutableBytes { (privPtr: UnsafeMutablePointer<UInt8>) in
+                privPtr[0] &= 248 // clear lowest bit
+                privPtr[31] &= 127 // clear highest bit
+                privPtr[31] |= 64 // set second highest bit
+                return basepoint.withUnsafeBytes { basepointPtr in
+                    curve25519_donna(keyPtr, privPtr, basepointPtr)
+                }
+            }
+        }
+//        let result: Int32 = data.withUnsafeMutableBytes { keyPtrBytes in
+//            if let keyPtr = keyPtrBytes.bindMemory(to: UInt8.self).baseAddress {
+//                privateKey.withUnsafeBytes { privPtrBytes in
+//                    if let privPtr = privPtrBytes.bindMemory(to: UInt8.self).baseAddress {
+//                        basepoint.withUnsafeBytes { basepointPtrBytes in
+//                            if let basepointPtr = basepointPtrBytes.bindMemory(to: UInt8.self).baseAddress {
+//                                curve25519_donna(keyPtr, privPtr, basepointPtr)
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
+        
+        guard result == 0 else {
+            throw "Incorrect result \(result)"
+        }
+        return data
+    }
+    
+    public static func signature(for message: Data, privateKey: Data, randomData: Data) throws -> Data {
+        let length = message.count
+        guard length > 0 else { throw "Incorrect message length: \(length)" }
+        guard randomData.count == Curve25519KeyLength.random else { throw "Incorrect private key length: \(randomData.count)" }
+        guard privateKey.count == Curve25519KeyLength.key else { throw "Incorrect private key length: \(privateKey.count)" }
+        
+        var signature = Data(count: Curve25519KeyLength.signature)
+        let result: Int32 = randomData.withUnsafeBytes{ randomPtr in
+            signature.withUnsafeMutableBytes { sigPtr in
+                privateKey.withUnsafeBytes{ keyPtr in
+                    message.withUnsafeBytes { messPtr in
+                        curve25519_sign(sigPtr, keyPtr, messPtr, UInt(length), randomPtr)
+                    }
+                }
+            }
+        }
+//        let result: Int32 = randomData.withUnsafeBytes{ randomPtrBytes in
+//            if let randomPtr = randomPtrBytes.bindMemory(to: UInt8.self).baseAddress {
+//                signature.withUnsafeMutableBytes { sigPtrBytes in
+//                    if let sigPtr = sigPtrBytes.bindMemory(to: UInt8.self).baseAddress {
+//                        privateKey.withUnsafeBytes{ keyPtrBytes in
+//                            if let keyPtr = keyPtrBytes.bindMemory(to: UInt8.self).baseAddress {
+//                                message.withUnsafeBytes { messPtrBytes in
+//                                    if let messPtr = messPtrBytes.bindMemory(to: UInt8.self).baseAddress {
+//                                        curve25519_sign(sigPtr, keyPtr, messPtr, UInt(length), randomPtr)
+//                                    }
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
+        guard result == 0 else {
+            throw "Incorrect result \(result)"
+        }
+        return signature
+    }
+}
+
+extension String: Error {}

--- a/Sources/TCNClient/Crypto/Curve25519PrivateKey.swift
+++ b/Sources/TCNClient/Crypto/Curve25519PrivateKey.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(CryptoKit)
 import CryptoKit
+#endif
 import CCurve25519
 
 public struct Curve25519KeyLength {
@@ -45,7 +47,7 @@ public struct Curve25519PrivateKey {
     
     /// Generates a Curve25519 Signing Key.
     public init() {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.2, *) {
             self.key = Curve25519.Signing.PrivateKey()
         } else {
             self.key = Curve25519PrivateKey.generateRandomData(count: Curve25519KeyLength.key)!
@@ -54,7 +56,7 @@ public struct Curve25519PrivateKey {
     }
     
     public init<D>(rawRepresentation data: D) throws where D : ContiguousBytes {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.2, *) {
             self.key = try Curve25519.Signing.PrivateKey(rawRepresentation: data)
         }
         else {
@@ -65,7 +67,7 @@ public struct Curve25519PrivateKey {
     
     // Initialize related public key
     private mutating func initPublicKey() throws {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.2, *) {
             if let key = key as? Curve25519.Signing.PrivateKey {
                 publicKey = Curve25519PublicKey(publicKey: key.publicKey)
                 return
@@ -76,7 +78,7 @@ public struct Curve25519PrivateKey {
     
     /// A data representation of the private key
     public var rawRepresentation: Data {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.2, *) {
             if let key = key as? Curve25519.Signing.PrivateKey {
                 return key.rawRepresentation
             }
@@ -90,7 +92,7 @@ public struct Curve25519PrivateKey {
     /// - Returns: The 64-bytes signature.
     /// - Throws: If there is a failure producing the signature.
     public func signature<D>(for data: D) throws -> Data where D : DataProtocol {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.2, *) {
             if let key = key as? Curve25519.Signing.PrivateKey {
                 return try key.signature(for: data)
             }

--- a/Sources/TCNClient/Crypto/Curve25519PrivateKey.swift
+++ b/Sources/TCNClient/Crypto/Curve25519PrivateKey.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import CryptoKit
+//import CryptoKit
 import CCurve25519
 
 public struct Curve25519KeyLength {
@@ -45,42 +45,42 @@ public struct Curve25519PrivateKey {
     
     /// Generates a Curve25519 Signing Key.
     public init() {
-        if #available(iOS 13.2, *) {
-            self.key = Curve25519.Signing.PrivateKey()
-        } else {
+//        if #available(iOS 13.2, *) {
+//            self.key = Curve25519.Signing.PrivateKey()
+//        } else {
             self.key = Curve25519PrivateKey.generateRandomData(count: Curve25519KeyLength.key)!
-        }
+//        }
         try! initPublicKey()
     }
     
     public init<D>(rawRepresentation data: D) throws where D : ContiguousBytes {
-        if #available(iOS 13.2, *) {
-            self.key = try Curve25519.Signing.PrivateKey(rawRepresentation: data)
-        }
-        else {
+//        if #available(iOS 13.2, *) {
+//            self.key = try Curve25519.Signing.PrivateKey(rawRepresentation: data)
+//        }
+//        else {
             self.key = data
-        }
+//        }
         try initPublicKey()
     }
     
     // Initialize related public key
     private mutating func initPublicKey() throws {
-        if #available(iOS 13.2, *) {
-            if let key = key as? Curve25519.Signing.PrivateKey {
-                publicKey = Curve25519PublicKey(publicKey: key.publicKey)
-                return
-            }
-        }
+//        if #available(iOS 13.2, *) {
+//            if let key = key as? Curve25519.Signing.PrivateKey {
+//                publicKey = Curve25519PublicKey(publicKey: key.publicKey)
+//                return
+//            }
+//        }
         publicKey = try Curve25519PublicKey(rawRepresentation: Curve25519PrivateKey.generatePublicKey(privateKey: key as! Data))
     }
     
     /// A data representation of the private key
     public var rawRepresentation: Data {
-        if #available(iOS 13.2, *) {
-            if let key = key as? Curve25519.Signing.PrivateKey {
-                return key.rawRepresentation
-            }
-        }
+//        if #available(iOS 13.2, *) {
+//            if let key = key as? Curve25519.Signing.PrivateKey {
+//                return key.rawRepresentation
+//            }
+//        }
         return key as! Data
     }
     
@@ -90,11 +90,11 @@ public struct Curve25519PrivateKey {
     /// - Returns: The 64-bytes signature.
     /// - Throws: If there is a failure producing the signature.
     public func signature<D>(for data: D) throws -> Data where D : DataProtocol {
-        if #available(iOS 13.2, *) {
-            if let key = key as? Curve25519.Signing.PrivateKey {
-                return try key.signature(for: data)
-            }
-        }
+//        if #available(iOS 13.2, *) {
+//            if let key = key as? Curve25519.Signing.PrivateKey {
+//                return try key.signature(for: data)
+//            }
+//        }
         return try Curve25519PrivateKey.signature(for: data as! Data, privateKey: key as! Data, randomData: Curve25519PrivateKey.generateRandomData(count: Curve25519KeyLength.random)!)
     }
     

--- a/Sources/TCNClient/Crypto/Curve25519PrivateKey.swift
+++ b/Sources/TCNClient/Crypto/Curve25519PrivateKey.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(CryptoKit)
 import CryptoKit
-#endif
 import CCurve25519
 
 public struct Curve25519KeyLength {

--- a/Sources/TCNClient/Crypto/Curve25519PublicKey.swift
+++ b/Sources/TCNClient/Crypto/Curve25519PublicKey.swift
@@ -1,0 +1,73 @@
+//
+//  Curve25519PublicKey.swift
+//  
+//
+//  Created by Volkov Alexander on 5/3/20.
+//
+
+import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+import CCurve25519
+
+public struct Curve25519PublicKey {
+    
+    public var key: Any!
+    
+    /// A data representation of the private key
+    public var rawRepresentation: Data {
+        if #available(iOS 13.0, *) {
+            if let key = key as? Curve25519.Signing.PublicKey {
+                return key.rawRepresentation
+            }
+        }
+        return key as! Data
+    }
+    
+    @available(iOS 13.0, *)
+    public init(publicKey: Curve25519.Signing.PublicKey) {
+        key = publicKey
+    }
+    
+    public init<D>(rawRepresentation: D) throws where D : ContiguousBytes {
+        if #available(iOS 13.0, *) {
+            key = try Curve25519.Signing.PublicKey(rawRepresentation: rawRepresentation)
+            return
+        }
+        key = rawRepresentation
+    }
+    
+    /// Verifies an EdDSA signature over Curve25519.
+    ///
+    /// - Parameters:
+    ///   - signature: The 64-bytes signature to verify.
+    ///   - data: The digest that was signed.
+    /// - Returns: True if the signature is valid. False otherwise.
+    public func isValidSignature<S, D>(_ signature: S, for data: D) -> Bool where S : DataProtocol, D : DataProtocol {
+        if #available(iOS 13.0, *) {
+            if let key = key as? Curve25519.Signing.PublicKey {
+                return key.isValidSignature(signature, for: data)
+            }
+        }
+        return Curve25519PublicKey.verify(signature: signature as! Data, for: data as! Data, publicKey: key as! Data)
+    }
+    
+    public static func verify(signature: Data, for message: Data, publicKey: Data) -> Bool {
+        guard signature.count == Curve25519KeyLength.signature,
+            publicKey.count == Curve25519KeyLength.key else {
+                return false
+        }
+        guard message.count > 0 else {
+            return false
+        }
+        let result: Int32 = signature.withUnsafeBytes { sigPtr in
+            publicKey.withUnsafeBytes { keyPtr in
+                message.withUnsafeBytes { msgPtr in
+                    curve25519_verify(sigPtr, keyPtr, msgPtr, UInt(message.count))
+                }
+            }
+        }
+        return result == 0
+    }
+}

--- a/Sources/TCNClient/Crypto/Curve25519PublicKey.swift
+++ b/Sources/TCNClient/Crypto/Curve25519PublicKey.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import CryptoKit
+//import CryptoKit
 import CCurve25519
 
 public struct Curve25519PublicKey {
@@ -15,24 +15,24 @@ public struct Curve25519PublicKey {
     
     /// A data representation of the private key
     public var rawRepresentation: Data {
-        if #available(iOS 13.2, *) {
-            if let key = key as? Curve25519.Signing.PublicKey {
-                return key.rawRepresentation
-            }
-        }
+//        if #available(iOS 13.2, *) {
+//            if let key = key as? Curve25519.Signing.PublicKey {
+//                return key.rawRepresentation
+//            }
+//        }
         return key as! Data
     }
-    
-    @available(iOS 13.0, *)
-    public init(publicKey: Curve25519.Signing.PublicKey) {
-        key = publicKey
-    }
+//    
+//    @available(iOS 13.0, *)
+//    public init(publicKey: Curve25519.Signing.PublicKey) {
+//        key = publicKey
+//    }
     
     public init<D>(rawRepresentation: D) throws where D : ContiguousBytes {
-        if #available(iOS 13.2, *) {
-            key = try Curve25519.Signing.PublicKey(rawRepresentation: rawRepresentation)
-            return
-        }
+//        if #available(iOS 13.2, *) {
+//            key = try Curve25519.Signing.PublicKey(rawRepresentation: rawRepresentation)
+//            return
+//        }
         key = rawRepresentation
     }
     
@@ -43,11 +43,11 @@ public struct Curve25519PublicKey {
     ///   - data: The digest that was signed.
     /// - Returns: True if the signature is valid. False otherwise.
     public func isValidSignature<S, D>(_ signature: S, for data: D) -> Bool where S : DataProtocol, D : DataProtocol {
-        if #available(iOS 13.2, *) {
-            if let key = key as? Curve25519.Signing.PublicKey {
-                return key.isValidSignature(signature, for: data)
-            }
-        }
+//        if #available(iOS 13.2, *) {
+//            if let key = key as? Curve25519.Signing.PublicKey {
+//                return key.isValidSignature(signature, for: data)
+//            }
+//        }
         return Curve25519PublicKey.verify(signature: signature as! Data, for: data as! Data, publicKey: key as! Data)
     }
     

--- a/Sources/TCNClient/Crypto/Curve25519PublicKey.swift
+++ b/Sources/TCNClient/Crypto/Curve25519PublicKey.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(CryptoKit)
 import CryptoKit
+#endif
 import CCurve25519
 
 public struct Curve25519PublicKey {
@@ -15,7 +17,7 @@ public struct Curve25519PublicKey {
     
     /// A data representation of the private key
     public var rawRepresentation: Data {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.2, *) {
             if let key = key as? Curve25519.Signing.PublicKey {
                 return key.rawRepresentation
             }
@@ -29,7 +31,7 @@ public struct Curve25519PublicKey {
     }
     
     public init<D>(rawRepresentation: D) throws where D : ContiguousBytes {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.2, *) {
             key = try Curve25519.Signing.PublicKey(rawRepresentation: rawRepresentation)
             return
         }
@@ -43,7 +45,7 @@ public struct Curve25519PublicKey {
     ///   - data: The digest that was signed.
     /// - Returns: True if the signature is valid. False otherwise.
     public func isValidSignature<S, D>(_ signature: S, for data: D) -> Bool where S : DataProtocol, D : DataProtocol {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.2, *) {
             if let key = key as? Curve25519.Signing.PublicKey {
                 return key.isValidSignature(signature, for: data)
             }

--- a/Sources/TCNClient/Crypto/Curve25519PublicKey.swift
+++ b/Sources/TCNClient/Crypto/Curve25519PublicKey.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(CryptoKit)
 import CryptoKit
-#endif
 import CCurve25519
 
 public struct Curve25519PublicKey {

--- a/Sources/TCNClient/Crypto/Keys.swift
+++ b/Sources/TCNClient/Crypto/Keys.swift
@@ -3,11 +3,11 @@
 //  
 
 import Foundation
-import CryptoKit
+//import CryptoKit
 import CommonCrypto
 
-@available(iOS 13.0, *)
-extension SHA256.Digest: DataRepresentable {}
+//@available(iOS 13.0, *)
+//extension SHA256.Digest: DataRepresentable {}
 extension UInt8: DataRepresentable {}
 extension UInt16: DataRepresentable {}
 extension MemoType: DataRepresentable {}
@@ -56,12 +56,12 @@ public struct ReportAuthorizationKey: Equatable {
 extension Data {
     
     func sha256Hash() -> Data {
-        if #available(iOS 13.2, *) {
-            let data =  SHA256.hash(data: self).dataRepresentation
-            return data
-        } else {
+//        if #available(iOS 13.2, *) {
+//            let data =  SHA256.hash(data: self).dataRepresentation
+//            return data
+//        } else {
             return (self as NSData).sha256Digest() as Data
-        }
+//        }
     }
 }
 extension NSData {

--- a/Sources/TCNClient/Crypto/Keys.swift
+++ b/Sources/TCNClient/Crypto/Keys.swift
@@ -3,9 +3,7 @@
 //  
 
 import Foundation
-#if canImport(CryptoKit)
 import CryptoKit
-#endif
 import CommonCrypto
 
 @available(iOS 13.0, *)

--- a/Sources/TCNClient/Crypto/Keys.swift
+++ b/Sources/TCNClient/Crypto/Keys.swift
@@ -3,7 +3,9 @@
 //  
 
 import Foundation
+#if canImport(CryptoKit)
 import CryptoKit
+#endif
 import CommonCrypto
 
 @available(iOS 13.0, *)
@@ -56,7 +58,7 @@ public struct ReportAuthorizationKey: Equatable {
 extension Data {
     
     func sha256Hash() -> Data {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.2, *) {
             let data =  SHA256.hash(data: self).dataRepresentation
             return data
         } else {

--- a/Sources/TCNClient/Crypto/Report.swift
+++ b/Sources/TCNClient/Crypto/Report.swift
@@ -3,7 +3,6 @@
 //  
 
 import Foundation
-import CryptoKit
 
 /// Describes the intended type of the contents of a memo field.
 public enum MemoType: UInt8 {
@@ -144,7 +143,7 @@ public struct SignedReport: Equatable {
     
     /// Verify the source integrity of the contained `report`.
     public func verify() throws -> Bool {
-        let publicKey = try Curve25519.Signing.PublicKey(
+        let publicKey = try Curve25519PublicKey(
             rawRepresentation: report.reportVerificationPublicKeyBytes
         )
         return publicKey.isValidSignature(

--- a/Sources/TCNClient/Crypto/Serialization.swift
+++ b/Sources/TCNClient/Crypto/Serialization.swift
@@ -3,7 +3,6 @@
 //  
 
 import Foundation
-import CryptoKit
 
 protocol TCNSerializable {
     
@@ -95,7 +94,7 @@ extension ReportAuthorizationKey: TCNSerializable {
         guard serializedData.count == 32 else {
             throw CocoaError(.coderInvalidValue)
         }
-        self.reportAuthorizationPrivateKey = try Curve25519.Signing.PrivateKey(
+        self.reportAuthorizationPrivateKey = try Curve25519PrivateKey(
             rawRepresentation: serializedData
         )
     }

--- a/TCNClient.podspec
+++ b/TCNClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "TCNClient"
-  s.version     = "1.0.4"
+  s.version     = "1.0.5"
   s.summary     = "The iOS client library for the TCN protocol."
   s.homepage    = "https://github.com/seriyvolk83/tcn-client-ios"
   s.license          = { :type => 'Apache', :file => 'LICENSE' }

--- a/TCNClient.podspec
+++ b/TCNClient.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name        = "TCNClient"
+  s.version     = "1.0.0"
+  s.summary     = "TCNClient"
+  s.homepage    = "https://github.com/seriyvolk83/tcn-client-ios"
+  s.license     = { :type => "MIT" }
+  s.authors     = { "zssz" => "https://github.com/TCNCoalition/tcn-client-ios/commits?author=zssz" }
+
+  s.requires_arc = true
+  s.swift_version = "5.1"
+  s.ios.deployment_target = "10.0"
+  s.source   = { :git => "https://github.com/seriyvolk83/tcn-client-ios.git", :tag => s.version }
+  s.source_files = "Source/*.swift"
+
+  s.default_subspec = "Core"
+
+  s.subspec 'Core' do |cs|
+    cs.source_files = "Source/*.swift"
+  end
+
+end
+

--- a/TCNClient.podspec
+++ b/TCNClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "TCNClient"
-  s.version     = "1.0.2"
+  s.version     = "1.0.3"
   s.summary     = "The iOS client library for the TCN protocol."
   s.homepage    = "https://github.com/seriyvolk83/tcn-client-ios"
   s.license          = { :type => 'Apache', :file => 'LICENSE' }

--- a/TCNClient.podspec
+++ b/TCNClient.podspec
@@ -1,16 +1,16 @@
 Pod::Spec.new do |s|
   s.name        = "TCNClient"
-  s.version     = "1.0.0"
-  s.summary     = "TCNClient"
+  s.version     = "1.0.1"
+  s.summary     = "The iOS client library for the TCN protocol."
   s.homepage    = "https://github.com/seriyvolk83/tcn-client-ios"
-  s.license     = { :type => "MIT" }
-  s.authors     = { "zssz" => "https://github.com/TCNCoalition/tcn-client-ios/commits?author=zssz" }
+  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.author           = { 'Zsombor Szabo' => 'zsombor@gmail.com' }
 
   s.requires_arc = true
-  s.swift_version = "5.1"
+  s.swift_version = "5.0"
   s.ios.deployment_target = "10.0"
   s.source   = { :git => "https://github.com/seriyvolk83/tcn-client-ios.git", :tag => s.version }
-  s.source_files = "Source/*.swift"
+  s.source_files = 'Sources/TCNClient/**/*'
 
   s.default_subspec = "Core"
 

--- a/TCNClient.podspec
+++ b/TCNClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "TCNClient"
-  s.version     = "1.0.3"
+  s.version     = "1.0.4"
   s.summary     = "The iOS client library for the TCN protocol."
   s.homepage    = "https://github.com/seriyvolk83/tcn-client-ios"
   s.license          = { :type => 'Apache', :file => 'LICENSE' }

--- a/TCNClient.podspec
+++ b/TCNClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "TCNClient"
-  s.version     = "1.0.1"
+  s.version     = "1.0.2"
   s.summary     = "The iOS client library for the TCN protocol."
   s.homepage    = "https://github.com/seriyvolk83/tcn-client-ios"
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
@@ -11,12 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "10.0"
   s.source   = { :git => "https://github.com/seriyvolk83/tcn-client-ios.git", :tag => s.version }
   s.source_files = 'Sources/TCNClient/**/*'
-
-  s.default_subspec = "Core"
-
-  s.subspec 'Core' do |cs|
-    cs.source_files = "Source/*.swift"
-  end
+  s.dependency 'CCurve25519'
 
 end
 

--- a/Tests/TCNClientTests/TCNClientCryptoTests.swift
+++ b/Tests/TCNClientTests/TCNClientCryptoTests.swift
@@ -108,7 +108,8 @@ final class TCNClientCryptoTests: XCTestCase {
             XCTAssertEqual(signedReport, newSignedReport)
             
             // Valid reports should verify correctly
-            _ = try signedReport.verify()
+            let res = try signedReport.verify()
+            XCTAssertTrue(res)
         }
         catch {
             XCTFail(error.localizedDescription)

--- a/Tests/TCNClientTests/TCNClientCryptoTests.swift
+++ b/Tests/TCNClientTests/TCNClientCryptoTests.swift
@@ -1,12 +1,14 @@
 import XCTest
+#if canImport(CryptoKit)
 import CryptoKit
+#endif
 @testable import TCNClient
 
 final class TCNClientCryptoTests: XCTestCase {
     
     func testSHA256() {
         let data = "Any data".data(using: .utf8)!
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.2, *) {
             let hash1 = SHA256.hash(data: data).dataRepresentation
             let hash2 = (data as NSData).sha256Digest() as Data
             XCTAssertEqual(hash1, hash2)

--- a/Tests/TCNClientTests/TCNClientCryptoTests.swift
+++ b/Tests/TCNClientTests/TCNClientCryptoTests.swift
@@ -1,8 +1,19 @@
 import XCTest
+#if canImport(CryptoKit)
 import CryptoKit
+#endif
 @testable import TCNClient
 
 final class TCNClientCryptoTests: XCTestCase {
+    
+    func testSHA256() {
+        let data = "Any data".data(using: .utf8)!
+        if #available(iOS 13.0, *) {
+            let hash1 = SHA256.hash(data: data).dataRepresentation
+            let hash2 = (data as NSData).sha256Digest() as Data
+            XCTAssertEqual(hash1, hash2)
+        }
+    }
     
     func testReportAuthorizationKeySerialization() {
         do {

--- a/Tests/TCNClientTests/TCNClientCryptoTests.swift
+++ b/Tests/TCNClientTests/TCNClientCryptoTests.swift
@@ -1,16 +1,16 @@
 import XCTest
-import CryptoKit
+//import CryptoKit
 @testable import TCNClient
 
 final class TCNClientCryptoTests: XCTestCase {
     
     func testSHA256() {
         let data = "Any data".data(using: .utf8)!
-        if #available(iOS 13.2, *) {
-            let hash1 = SHA256.hash(data: data).dataRepresentation
-            let hash2 = (data as NSData).sha256Digest() as Data
-            XCTAssertEqual(hash1, hash2)
-        }
+//        if #available(iOS 13.2, *) {
+//            let hash1 = SHA256.hash(data: data).dataRepresentation
+//            let hash2 = (data as NSData).sha256Digest() as Data
+//            XCTAssertEqual(hash1, hash2)
+//        }
     }
     
     func testReportAuthorizationKeySerialization() {

--- a/Tests/TCNClientTests/TCNClientCryptoTests.swift
+++ b/Tests/TCNClientTests/TCNClientCryptoTests.swift
@@ -1,7 +1,5 @@
 import XCTest
-#if canImport(CryptoKit)
 import CryptoKit
-#endif
 @testable import TCNClient
 
 final class TCNClientCryptoTests: XCTestCase {


### PR DESCRIPTION
CCurve25519 requires extra into parameter - basepoint for public key generation. It uses:
```
var basepoint: Data = [9] + Data(repeating: 0, count: 31)
```